### PR TITLE
Fix a warning and add more explicit logging

### DIFF
--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -81,11 +81,12 @@ class Client
         $this->logger->debug(sprintf("Response:\n%s\n%s\n%s", $response->getStatusCode(), json_encode($response->getHeaders()), $response->getBody()->getContents()));
 
         if (400 <= $response->getStatusCode()) {
-            $message = sprintf('Something went wrong when calling consul (%s - %s).', $response->getStatusCode(), $response->getReasonPhrase());
+            $message = sprintf('Something went wrong when calling consul statusCode=[%s] reasonPhrase=[%s] uri=[%s]).', $response->getStatusCode(), $response->getReasonPhrase(), $request->getUri());
 
             $this->logger->error($message);
 
-            $message .= "\n$response";
+
+            $message .= "\n" . $response->getBody()->__toString();
             if (500 <= $response->getStatusCode()) {
                 throw new ServerException($message);
             }


### PR DESCRIPTION
Fix a warning and add more explicit logging

The error being fixed is ```{"level":4,"code":4096,"error":"Warning","description":"Object of class GuzzleHttp\\Psr7\\Response could not be converted to string","file":"\/mnt\/hgfs\/platform\/vendor\/life360\/consul-php-sdk\/Consul\/Client.php","line":88,"context":{"request":{},"response":{},"message":"Something went wrong when calling consul (404 - Not Found)."},"start":2,"path":"ROOT\/vendor\/life360\/consul-php-sdk\/Consul\/Client.php"}```

The logging change is to add the consul uri when a warning of this kind comes up so we can see which key is being queried.